### PR TITLE
Throw TypeError when wrong PySwip version is being used

### DIFF
--- a/src/deepproblog/engines/prolog_engine/swi_program.py
+++ b/src/deepproblog/engines/prolog_engine/swi_program.py
@@ -322,6 +322,14 @@ class SWIProgram(ProbLogObject):
                 for k in r:
                     v = result[0][k]
                     if type(v) is list:
+                        if isinstance(v[0], str):
+                            raise TypeError("Oops, it appears you are using the wrong version of PySwip.\n"
+                                            "Please make sure you are using PySwip from https://github.com/ML-KULeuven/pyswip\n"
+                                            "To install, first remove your current PySwip version, then install the correct version.\n"
+                                            "You can try doing\n'pip install git+https://github.com/ML-KULeuven/pyswip'.\n"
+                                            "For some reason, this does not always resolve the issue. If you still get this error,\n"
+                                            "clone the repo locally, then compile from your local codebase doing\n"
+                                            "'pip install [path to local clone]'.")
                         out_partial[k] = [p for p in term2list(parse(result[0][k]))]
                     else:
                         out_partial[k] = parse(v)


### PR DESCRIPTION
Altered swi_program.py to throw a TypeError when the result of the query seems to have been normalized by PySwip, i.e., the user is using the wrong PySwip version. The error message includes directions for how to resolve the issue.