### PR TITLE
Add necessary readthedocs.yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,6 +27,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+    - requirements: src/docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: src/docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/src/docs/requirements.txt
+++ b/src/docs/requirements.txt
@@ -1,0 +1,4 @@
+problog
+torchvision
+torch
+furo

--- a/src/docs/source/conf.py
+++ b/src/docs/source/conf.py
@@ -51,6 +51,6 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "default"
-# html_theme = 'furo'
-# html_static_path = ['_static']
+#html_theme = "default"
+html_theme = 'furo'
+html_static_path = ['_static']

--- a/src/docs/source/conf.py
+++ b/src/docs/source/conf.py
@@ -51,6 +51,7 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
+RTD_NEW_THEME = True
 html_theme = "default"
 # html_theme = 'furo'
 # html_static_path = ['_static']

--- a/src/docs/source/conf.py
+++ b/src/docs/source/conf.py
@@ -51,5 +51,6 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'furo'
-html_static_path = ['_static']
+theme: readthedocs
+# html_theme = 'furo'
+# html_static_path = ['_static']

--- a/src/docs/source/conf.py
+++ b/src/docs/source/conf.py
@@ -51,7 +51,6 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-RTD_NEW_THEME = True
 html_theme = "default"
 # html_theme = 'furo'
 # html_static_path = ['_static']

--- a/src/docs/source/conf.py
+++ b/src/docs/source/conf.py
@@ -51,6 +51,6 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-theme: readthedocs
+html_theme = "default"
 # html_theme = 'furo'
 # html_static_path = ['_static']


### PR DESCRIPTION
Add necessary readthedocs.yaml file and requirements for letting readthedocs build the documentation, now readthedocs should be able to automatically build documentation without errors